### PR TITLE
show weather-widget icon in general tab fix

### DIFF
--- a/package/contents/config/config.qml
+++ b/package/contents/config/config.qml
@@ -4,7 +4,7 @@ import org.kde.plasma.configuration 2.0
 ConfigModel {
     ConfigCategory {
          name: i18n('General')
-         icon: Qt.resolvedUrl('../images/weather-widget.svg')
+         icon: 'weather-widget'
          source: 'config/ConfigGeneral.qml'
     }
     ConfigCategory {


### PR DESCRIPTION
@kotelnik dirty way
Papirus:
![screenshot_20160328_125401](https://cloud.githubusercontent.com/assets/9846948/14076728/cd29285c-f4e4-11e5-9dd8-6984ec3a9da7.png)
Breeze:
![screenshot_20160328_130301](https://cloud.githubusercontent.com/assets/9846948/14076820/7ea4c0f0-f4e5-11e5-82cc-029daad9862a.png)

IF `weather-widget` icon is present in current using icon theme, then will be used OFC.
General icon should be installed in path:

`${pkgdir}/usr/share/icons/hicolor/scalable/apps/weather-widget.svg`

Just add to PKGBUILD code BEFORE `cd build`

`install -Dm644 ${srcdir}/"${_gitpkgname}"/package/contents/images/weather-widget.svg ${pkgdir}/usr/share/icons/hicolor/scalable/apps/weather-widget.svg`

Regards

Tomasz