### PR TITLE
Fix translation

### DIFF
--- a/translations/po/plasma_applet_org.kde.weatherWidget_ru.po
+++ b/translations/po/plasma_applet_org.kde.weatherWidget_ru.po
@@ -35,7 +35,7 @@ msgstr ""
 #: ../package/contents/code/unit-utils.js:57
 #: ../package/contents/ui/config/ConfigUnits.qml:144
 msgid "mmHg"
-msgstr "мм рт.ст."
+msgstr "Торр (мм рт.ст.)"
 
 #: ../package/contents/code/unit-utils.js:59
 #: ../package/contents/ui/config/ConfigUnits.qml:127
@@ -50,7 +50,7 @@ msgstr ""
 #: ../package/contents/code/unit-utils.js:88
 #: ../package/contents/ui/config/ConfigUnits.qml:178
 msgid "km/h"
-msgstr ""
+msgstr "км/ч"
 
 #: ../package/contents/code/unit-utils.js:90
 #: ../package/contents/ui/config/ConfigUnits.qml:161


### PR DESCRIPTION
Add translation for km/h. Fix translation for mmHg (мм рт.ст. didn't fit in meteogramm, only 'мм рт.')